### PR TITLE
Render config editor, validate & save config to firebase

### DIFF
--- a/lib/controller.dart
+++ b/lib/controller.dart
@@ -512,6 +512,7 @@ void command(UIAction action, Data data) async {
 }
 
 void validateConfig(model.Config config) {
+  // Data paths
   if (config.data_paths == null) {
     throw StateError('data_paths cannot be empty');
   }
@@ -520,8 +521,9 @@ void validateConfig(model.Config config) {
     throw StateError('data_paths > interactions cannot be empty');
   }
 
+  // Filters
   if (config.filters == null) {
-    throw StateError('filters cannot be empty');
+    throw StateError('filters need to be an array');
   }
 
   for (var filter in config.filters) {
@@ -530,9 +532,31 @@ void validateConfig(model.Config config) {
     }
   }
 
+  // Tabs
   if (config.tabs == null) {
     throw StateError('tabs cannot be empty');
   }
 
-  // todo: Add more?
+  for (var tab in config.tabs) {
+    for (var chart in tab.charts) {
+      for (var field in chart.fields) {
+        if (field.field.key == null) {
+          throw StateError('Chart field cannot be empty');
+        }
+        if (field.field.value == null) {
+          throw StateError('Chart field value cannot be empty');
+        }
+        // no need to check for operator, as it is caught by enums
+      }
+
+      // geography map
+      if (chart.type == model.ChartType.map) {
+        if (chart.geography == null ||
+            chart.geography.country == null ||
+            chart.geography.regionLevel == null) {
+          throw StateError('Geography map not specified');
+        }
+      }
+    }
+  }
 }

--- a/lib/controller.dart
+++ b/lib/controller.dart
@@ -502,7 +502,15 @@ void command(UIAction action, Data data) async {
         }
         return;
       }
-      await fb.updateConfig(configJSON);
+
+      try {
+        await fb.updateConfig(configJSON);
+      } catch (e) {
+        view.showAlert(e);
+        logger.error(e);
+        return;
+      }
+
       view.showConfigSettingsAlert('Config saved successfully', false);
       _configRaw = configJSON;
       _config = model.Config.fromData(_configRaw);

--- a/lib/firebase.dart
+++ b/lib/firebase.dart
@@ -82,6 +82,12 @@ Future<Map<String, dynamic>> fetchConfig() async {
   return configSnapshot.data();
 }
 
+Future<Null> updateConfig(Map<String, dynamic> data) async {
+  var chartsConfigRef = firebase.firestore().doc(fb_constants.metadataPath);
+  var configSnap = await chartsConfigRef.update(data: data);
+  return configSnap;
+}
+
 Future<Map<String, Map<String, dynamic>>> fetchInteractions(String path) async {
   if (path == null || path == '') {
     throw ArgumentError(

--- a/lib/firebase.dart
+++ b/lib/firebase.dart
@@ -1,7 +1,6 @@
 import 'package:firebase/firebase.dart' as firebase;
 import 'package:dashboard/firebase_constants.dart' as fb_constants;
 import 'package:dashboard/view.dart' as view;
-import 'package:dashboard/model.dart' as model;
 import 'package:dashboard/logger.dart';
 
 Logger logger = Logger('firebase.dart');
@@ -76,13 +75,11 @@ void _fbAuthChanged(
 }
 
 // Read data
-Future<model.Config> fetchConfig() async {
+Future<Map<String, dynamic>> fetchConfig() async {
   logger.debug('Fetching config from firebase ..');
   var chartsConfigRef = firebase.firestore().doc(fb_constants.metadataPath);
   var configSnapshot = await chartsConfigRef.get();
-  var configData = configSnapshot.data();
-
-  return model.Config.fromData(configData);
+  return configSnapshot.data();
 }
 
 Future<Map<String, Map<String, dynamic>>> fetchInteractions(String path) async {

--- a/lib/view.dart
+++ b/lib/view.dart
@@ -3,6 +3,7 @@ import 'controller.dart';
 import 'package:chartjs/chartjs.dart' as chartjs;
 import 'package:mapbox_gl_dart/mapbox_gl_dart.dart';
 import 'package:dashboard/geomap_helpers.dart' as geomap_helpers;
+import 'package:codemirror/codemirror.dart' as code_mirror;
 
 const LOADING_MODAL_ID = 'loading-modal';
 
@@ -528,9 +529,27 @@ html.SelectElement _getDropdown(String id, List<String> options,
   return dropdownSelect;
 }
 
-void renderSettingsTab() {
-  clearContentTab();
-  content.append(html.DivElement()..innerText = 'Settings');
+void renderSettingsTab(String config) {
+  var wrapper = html.DivElement();
+  var textArea = html.TextAreaElement()
+    ..text = config
+    ..setAttribute('rows', '30');
+  var saveButton = html.ButtonElement()
+    ..classes = ['btn', 'btn-primary']
+    ..text = 'Update config';
+
+  wrapper.append(textArea);
+  wrapper.append(saveButton);
+  content.append(wrapper);
+
+  var editor = code_mirror.CodeMirror.fromTextArea(textArea, options: {
+    'mode': 'javascript',
+    'theme': 'default',
+    'lineNumbers': true,
+    'autoRefresh': true
+  });
+  editor.setSize(null, 600);
+  editor.focus();
 }
 
 void render404() {

--- a/lib/view.dart
+++ b/lib/view.dart
@@ -22,6 +22,7 @@ const CARD_CLASSNAME = 'card';
 const CARD_BODY_CLASSNAME = 'card-body';
 const CHART_WRAPPER_CLASSNAME = 'chart';
 const MAPBOX_COL_CLASSNAME = 'mapbox-col';
+const CONFIG_SETTINGS_ALERT_ID = 'config-settings-alert';
 
 const CONTENT_ID = 'content';
 
@@ -47,6 +48,8 @@ html.DivElement get filtersWrapper =>
     html.querySelector('#${FILTERS_WRAPPER_ID}');
 List<html.DivElement> get chartWrappers =>
     html.querySelectorAll('.${CHART_WRAPPER_CLASSNAME}');
+html.DivElement get configSettingsAlert =>
+    html.querySelector('#${CONFIG_SETTINGS_ALERT_ID}');
 
 String _generateFilterRowID(String key) => 'filter-row-${key}';
 String _generateFilterDropdownID(String key) => 'filter-dropdown-${key}';
@@ -534,16 +537,12 @@ html.SelectElement _getDropdown(String id, List<String> options,
 
 void renderSettingsTab(String config) {
   var wrapper = html.DivElement();
+  content.append(wrapper);
+
   var textArea = html.TextAreaElement()
     ..text = config
     ..setAttribute('rows', '30');
-  var saveButton = html.ButtonElement()
-    ..classes = ['btn', 'btn-primary']
-    ..text = 'Update config';
-
   wrapper.append(textArea);
-  wrapper.append(saveButton);
-  content.append(wrapper);
 
   var editor = code_mirror.CodeMirror.fromTextArea(textArea, options: {
     'mode': 'javascript',
@@ -553,6 +552,35 @@ void renderSettingsTab(String config) {
   });
   editor.setSize(null, 600);
   editor.focus();
+
+  var alertElement = html.DivElement()
+    ..classes = ['alert']
+    ..id = CONFIG_SETTINGS_ALERT_ID
+    ..hidden = true;
+  wrapper.append(alertElement);
+
+  var saveButton = html.ButtonElement()
+    ..classes = ['btn', 'btn-primary']
+    ..text = 'Update config'
+    ..onClick.listen((e) {
+      var data = editor.getDoc().getValue();
+      command(UIAction.saveConfigToFirebase, SaveConfigToFirebaseData(data));
+    });
+  wrapper.append(saveButton);
+}
+
+void showConfigSettingsAlert(String message, bool isError) {
+  configSettingsAlert
+    ..text = message
+    ..classes.toggle('alert-danger', isError)
+    ..classes.toggle('alert-success', !isError)
+    ..hidden = false;
+}
+
+void hideConfigSettingsAlert() {
+  configSettingsAlert
+    ..text = ''
+    ..hidden = true;
 }
 
 void render404() {

--- a/lib/view.dart
+++ b/lib/view.dart
@@ -539,17 +539,11 @@ void renderSettingsTab(String config) {
   var wrapper = html.DivElement();
   content.append(wrapper);
 
-  var textArea = html.TextAreaElement()
-    ..text = config
-    ..setAttribute('rows', '30');
+  var textArea = html.TextAreaElement()..text = config;
   wrapper.append(textArea);
 
-  var editor = code_mirror.CodeMirror.fromTextArea(textArea, options: {
-    'mode': 'javascript',
-    'theme': 'default',
-    'lineNumbers': true,
-    'autoRefresh': true
-  });
+  var editor = code_mirror.CodeMirror.fromTextArea(textArea,
+      options: {'mode': 'javascript', 'lineNumbers': true});
   editor.setSize(null, 600);
   editor.focus();
 
@@ -581,11 +575,6 @@ void hideConfigSettingsAlert() {
   configSettingsAlert
     ..text = ''
     ..hidden = true;
-}
-
-void render404() {
-  clearContentTab();
-  content.append(html.DivElement()..innerText = '404 page not found');
 }
 
 void showAlert(String message) {

--- a/lib/view.dart
+++ b/lib/view.dart
@@ -542,8 +542,10 @@ void renderSettingsTab(String config) {
   var textArea = html.TextAreaElement()..text = config;
   wrapper.append(textArea);
 
-  var editor = code_mirror.CodeMirror.fromTextArea(textArea,
-      options: {'mode': 'javascript', 'lineNumbers': true});
+  var editor = code_mirror.CodeMirror.fromTextArea(textArea, options: {
+    'mode': {'name': 'javascript', 'json': true},
+    'lineNumbers': true
+  });
   editor.setSize(null, 600);
   editor.focus();
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,7 @@ dependencies:
   chartjs:
     git: git@github.com:marianamarasoiu/chartjs.dart.git
   mapbox_gl_dart: ^0.1.4
+  codemirror: ^0.5.16+5.53.0
 
 dev_dependencies:
   build_runner: ^1.6.0

--- a/web/index.html
+++ b/web/index.html
@@ -21,6 +21,9 @@
       href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.5.0/mapbox-gl.css"
       rel="stylesheet"
     />
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.55.0/codemirror.min.js"></script>
+    <link href="packages/codemirror/codemirror.css" rel="stylesheet" />
+    <script src="packages/codemirror/codemirror.js"></script>
     <script defer src="script.dart.js"></script>
   </head>
 

--- a/web/style/index.css
+++ b/web/style/index.css
@@ -14,3 +14,7 @@
   max-width: calc(100% - 30px);
   border: 1px solid #b3b3b3;
 }
+
+.CodeMirror {
+  border: 1px solid #000;
+}


### PR DESCRIPTION
+ Added code mirror to display & edit the config json
+ Validate model checks for the missing fields that are required in the config

+ Firebase fetch config returns the raw config instead of converting to model. This change helps me to display the config directly in the code mirror instead of raw -> model -> raw + removing the artefacts of model conversion like enum names. 

+ Reset UI data states when switching back from settings to analyse tab
+ Removed unused methods