### PR TITLE
2 decimal places for normalised chart values

### DIFF
--- a/lib/chart_helpers.dart
+++ b/lib/chart_helpers.dart
@@ -10,7 +10,7 @@ String _generateLegendLabelFromFilters(Map<String, String> filters) {
 }
 
 ChartDataSets _generateBarChartDataset(
-    String label, List<int> data, String barColor) {
+    String label, List<num> data, String barColor) {
   return ChartDataSets(
       label: label,
       fill: true,
@@ -58,8 +58,8 @@ ChartConfiguration generateBarChartConfig(
     Map<String, String> activeFilterValues,
     Map<String, String> activeComparisonFilterValues) {
   var labels = [];
-  var filterData = List<int>();
-  var comparisonFilterData = List<int>();
+  var filterData = List<num>();
+  var comparisonFilterData = List<num>();
 
   for (var chartCol in chart.fields) {
     labels.add(chartCol.label ?? chartCol.field.value);

--- a/lib/controller.dart
+++ b/lib/controller.dart
@@ -281,9 +281,13 @@ void _computeChartBuckets(List<model.Chart> charts) {
   if (_dataNormalisationEnabled) {
     for (var chart in charts) {
       for (var chartCol in chart.fields) {
+        var filterValuesPercent = chartCol.bucket[0] * 100 / _filterValuesCount;
+        var comparisonFilterValuesPercent =
+            chartCol.bucket[1] * 100 / _comparisonFilterValuesCount;
+
         chartCol.bucket = [
-          (chartCol.bucket[0] * 100 / _filterValuesCount).truncate(),
-          (chartCol.bucket[1] * 100 / _comparisonFilterValuesCount).truncate()
+          num.parse(filterValuesPercent.toStringAsFixed(2)),
+          num.parse(comparisonFilterValuesPercent.toStringAsFixed(2))
         ];
       }
     }

--- a/lib/controller.dart
+++ b/lib/controller.dart
@@ -6,6 +6,7 @@ import 'package:dashboard/model.dart' as model;
 import 'package:dashboard/view.dart' as view;
 import 'package:dashboard/firebase.dart' as fb;
 import 'package:dashboard/chart_helpers.dart' as chart_helper;
+import 'package:dashboard/extensions.dart';
 import 'package:dashboard/logger.dart';
 
 Logger logger = Logger('controller.dart');
@@ -281,13 +282,13 @@ void _computeChartBuckets(List<model.Chart> charts) {
   if (_dataNormalisationEnabled) {
     for (var chart in charts) {
       for (var chartCol in chart.fields) {
-        var filterValuesPercent = chartCol.bucket[0] * 100 / _filterValuesCount;
-        var comparisonFilterValuesPercent =
+        num filterValuesPercent = chartCol.bucket[0] * 100 / _filterValuesCount;
+        num comparisonFilterValuesPercent =
             chartCol.bucket[1] * 100 / _comparisonFilterValuesCount;
 
         chartCol.bucket = [
-          num.parse(filterValuesPercent.toStringAsFixed(2)),
-          num.parse(comparisonFilterValuesPercent.toStringAsFixed(2))
+          filterValuesPercent.roundToDecimal(2),
+          comparisonFilterValuesPercent.roundToDecimal(2)
         ];
       }
     }

--- a/lib/extensions.dart
+++ b/lib/extensions.dart
@@ -1,0 +1,8 @@
+import 'dart:math' as math;
+
+extension RoundDecimals on num {
+  num roundToDecimal(int fractionDigits) {
+    var n = math.pow(10, fractionDigits);
+    return (this * n).round() / n;
+  }
+}

--- a/lib/model.g.dart
+++ b/lib/model.g.dart
@@ -128,7 +128,7 @@ class Field {
   String docId;
   String label;
   String tooltip;
-  List<int> bucket;
+  List<num> bucket;
   FieldOperation field;
 
   static Field fromSnapshot(DocSnapshot doc, [Field modelObj]) =>
@@ -139,7 +139,7 @@ class Field {
     return (modelObj ?? Field())
       ..label = String_fromData(data['label'])
       ..tooltip = String_fromData(data['tooltip'])
-      ..bucket = List_fromData<int>(data['bucket'], int_fromData)
+      ..bucket = List_fromData<num>(data['bucket'], num_fromData)
       ..field = FieldOperation.fromData(data['field']);
   }
 
@@ -405,6 +405,17 @@ int int_fromData(data) {
 }
 
 String String_fromData(data) => data?.toString();
+
+num num_fromData(data) {
+  if (data == null) return null;
+  if (data is num) return data;
+  if (data is String) {
+    var result = num.tryParse(data);
+    if (result is num) return result;
+  }
+  log.warning('unknown num value: ${data?.toString()}');
+  return null;
+}
 
 List<T> List_fromData<T>(dynamic data, T createModel(data)) =>
     (data as List)?.map<T>((elem) => createModel(elem))?.toList();

--- a/lib/model.yaml
+++ b/lib/model.yaml
@@ -19,7 +19,7 @@ Chart:
 Field:
   label: "string" #optional
   tooltip: "string" #optional
-  bucket: "array int" #optional
+  bucket: "array num" #optional
   field: FieldOperation
 
 FieldOperation:


### PR DESCRIPTION
+ Chart buckets is now `num` instead of `int`
+ Instead of truncating the percentage for chart field values, rounding off to 2 decimal places

Related to https://github.com/larksystems/katikati-reporting/pull/22#pullrequestreview-440748326