### PR TITLE
Rendering basic time series charts

### DIFF
--- a/lib/chart_helpers.dart
+++ b/lib/chart_helpers.dart
@@ -1,7 +1,7 @@
 import 'dart:js';
 import 'package:dashboard/model.dart' as model;
 import 'package:chartjs/chartjs.dart';
-import 'package:intl/intl.dart';
+import 'package:intl/intl.dart' as intl;
 
 const barChartDefaultColors = ['#ef5350', '#07acc1'];
 const lineChartDefaultColors = [
@@ -200,10 +200,10 @@ ChartConfiguration generateTimeSeriesChartConfig(model.Chart chart,
             var date = DateTime.parse(key);
             switch (chart.timestamp.aggregate) {
               case model.TimeAggregate.day:
-                return DateFormat('dd MMM').format(date);
+                return intl.DateFormat('dd MMM').format(date);
               case model.TimeAggregate.hour:
               default:
-                return DateFormat('dd MMM h:mm a').format(date);
+                return intl.DateFormat('dd MMM h:mm a').format(date);
             }
           }).toList(),
           datasets: datasets),

--- a/lib/chart_helpers.dart
+++ b/lib/chart_helpers.dart
@@ -1,8 +1,42 @@
 import 'dart:js';
 import 'package:dashboard/model.dart' as model;
 import 'package:chartjs/chartjs.dart';
+import 'package:intl/intl.dart';
 
 const barChartDefaultColors = ['#ef5350', '#07acc1'];
+const lineChartDefaultColors = [
+  '#3366cc',
+  '#dc3912',
+  '#ff9900',
+  '#109618',
+  '#990099',
+  '#0099c6',
+  '#dd4477',
+  '#66aa00',
+  '#b82e2e',
+  '#316395',
+  '#994499',
+  '#22aa99',
+  '#aaaa11',
+  '#6633cc',
+  '#e67300',
+  '#8b0707',
+  '#651067',
+  '#329262',
+  '#5574a6',
+  '#3b3eac',
+  '#b77322',
+  '#16d620',
+  '#b91383',
+  '#f4359e',
+  '#9c5935',
+  '#a9c413',
+  '#2a778d',
+  '#668d1c',
+  '#bea413',
+  '#0c5922',
+  '#743411'
+];
 const allInteractionsLabel = 'All interactions';
 
 String _generateLegendLabelFromFilters(Map<String, String> filters) {
@@ -92,4 +126,78 @@ ChartConfiguration generateBarChartConfig(
       type: 'bar',
       data: dataset,
       options: _generateBarChartOptions(dataNormalisationEnabled));
+}
+
+ChartOptions _generateTimeSeriesChartOptions(bool dataNormalisationEnabled) {
+  var labelPrepend = dataNormalisationEnabled ? 'Percentage' : 'Number';
+  var labelString = '${labelPrepend} of interactions';
+  var chartX = ChartXAxe()
+    ..stacked = false
+    ..ticks = (LinearTickOptions()
+      ..minRotation = 0
+      ..maxRotation = 90);
+
+  var chartY = ChartYAxe()
+    ..stacked = false
+    ..scaleLabel = ScaleTitleOptions(labelString: labelString, display: true)
+    ..ticks = (LinearTickOptions()..min = 0);
+
+  var tooltipLabelCallback = (ChartTooltipItem tooltipItem, ChartData data) {
+    var xLabel = data.datasets[tooltipItem.datasetIndex].label;
+    var yLabel = tooltipItem.yLabel;
+    var suffix = dataNormalisationEnabled ? '%' : '';
+    return '${xLabel}: ${yLabel}${suffix}';
+  };
+
+  return ChartOptions(
+      responsive: true,
+      tooltips: ChartTooltipOptions(
+          mode: 'index',
+          callbacks:
+              ChartTooltipCallback(label: allowInterop(tooltipLabelCallback))),
+      legend: ChartLegendOptions(
+          position: 'bottom', labels: ChartLegendLabelOptions(boxWidth: 12)),
+      scales: ChartScales(display: true, xAxes: [chartX], yAxes: [chartY]));
+}
+
+ChartDataSets _generateTimeSeriesChartDataset(
+    String label, List<num> data, String lineColor) {
+  return ChartDataSets(
+      label: label,
+      fill: false,
+      backgroundColor: lineColor + 'aa',
+      borderColor: lineColor,
+      hoverBackgroundColor: lineColor,
+      hoverBorderColor: lineColor,
+      borderWidth: 1,
+      lineTension: 0,
+      data: data);
+}
+
+ChartConfiguration generateTimeSeriesChartConfig(
+    model.Chart chart, bool dataNormalisationEnabled) {
+  var colors = chart.colors ?? lineChartDefaultColors;
+  var datasets = chart.fields.asMap().entries.map((entry) {
+    var index = entry.key;
+    var field = entry.value;
+    return _generateTimeSeriesChartDataset(field.label ?? field.field,
+        field.time_bucket.values.toList(), colors[index]);
+  }).toList();
+
+  return ChartConfiguration(
+      type: 'line',
+      data: ChartData(
+          labels: chart.fields.first.time_bucket.keys.map((key) {
+            var date = DateTime.parse(key);
+            switch (chart.timestamp.aggregate) {
+              case model.TimeAggregate.day:
+                return DateFormat('dd MMM').format(date);
+              case model.TimeAggregate.hour:
+                return DateFormat('dd MMM h:mm a').format(date);
+              default:
+                return DateFormat('dd MMM h:mm a').format(date);
+            }
+          }).toList(),
+          datasets: datasets),
+      options: _generateTimeSeriesChartOptions(dataNormalisationEnabled));
 }

--- a/lib/chart_helpers.dart
+++ b/lib/chart_helpers.dart
@@ -169,6 +169,8 @@ ChartDataSets _generateTimeSeriesChartDataset(
       borderColor: lineColor,
       hoverBackgroundColor: lineColor,
       hoverBorderColor: lineColor,
+      pointHoverBackgroundColor: lineColor,
+      pointRadius: 2,
       borderWidth: 1,
       lineTension: 0,
       data: data);
@@ -176,7 +178,7 @@ ChartDataSets _generateTimeSeriesChartDataset(
 
 ChartConfiguration generateTimeSeriesChartConfig(
     model.Chart chart, bool dataNormalisationEnabled) {
-  var colors = chart.colors ?? lineChartDefaultColors;
+  var colors = (chart.colors ?? [])..addAll(lineChartDefaultColors);
   var datasets = chart.fields.asMap().entries.map((entry) {
     var index = entry.key;
     var field = entry.value;

--- a/lib/chart_helpers.dart
+++ b/lib/chart_helpers.dart
@@ -49,7 +49,7 @@ ChartDataSets _generateBarChartDataset(
   return ChartDataSets(
       label: label,
       fill: true,
-      backgroundColor: barColor + 'aa',
+      backgroundColor: '${barColor}aa',
       borderColor: barColor,
       hoverBackgroundColor: barColor,
       hoverBorderColor: barColor,
@@ -165,7 +165,7 @@ ChartDataSets _generateTimeSeriesChartDataset(
   return ChartDataSets(
       label: label,
       fill: false,
-      backgroundColor: lineColor + 'aa',
+      backgroundColor: '${lineColor}aa',
       borderColor: lineColor,
       hoverBackgroundColor: lineColor,
       hoverBorderColor: lineColor,
@@ -193,7 +193,6 @@ ChartConfiguration generateTimeSeriesChartConfig(
               case model.TimeAggregate.day:
                 return DateFormat('dd MMM').format(date);
               case model.TimeAggregate.hour:
-                return DateFormat('dd MMM h:mm a').format(date);
               default:
                 return DateFormat('dd MMM h:mm a').format(date);
             }

--- a/lib/chart_helpers.dart
+++ b/lib/chart_helpers.dart
@@ -128,7 +128,8 @@ ChartConfiguration generateBarChartConfig(
       options: _generateBarChartOptions(dataNormalisationEnabled));
 }
 
-ChartOptions _generateTimeSeriesChartOptions(bool dataNormalisationEnabled) {
+ChartOptions _generateTimeSeriesChartOptions(
+    bool dataNormalisationEnabled, bool stackTimeseriesEnabled) {
   var labelPrepend = dataNormalisationEnabled ? 'Percentage' : 'Number';
   var labelString = '${labelPrepend} of interactions';
   var chartX = ChartXAxe()
@@ -138,9 +139,12 @@ ChartOptions _generateTimeSeriesChartOptions(bool dataNormalisationEnabled) {
       ..maxRotation = 90);
 
   var chartY = ChartYAxe()
-    ..stacked = false
+    ..stacked = stackTimeseriesEnabled
     ..scaleLabel = ScaleTitleOptions(labelString: labelString, display: true)
     ..ticks = (LinearTickOptions()..min = 0);
+  if (dataNormalisationEnabled) {
+    chartY.ticks.max = 100;
+  }
 
   var tooltipLabelCallback = (ChartTooltipItem tooltipItem, ChartData data) {
     var xLabel = data.datasets[tooltipItem.datasetIndex].label;
@@ -161,11 +165,11 @@ ChartOptions _generateTimeSeriesChartOptions(bool dataNormalisationEnabled) {
 }
 
 ChartDataSets _generateTimeSeriesChartDataset(
-    String label, List<num> data, String lineColor) {
+    String label, List<num> data, String lineColor, dynamic filled) {
   return ChartDataSets(
       label: label,
-      fill: false,
-      backgroundColor: lineColor + 'aa',
+      fill: filled,
+      backgroundColor: lineColor + '55',
       borderColor: lineColor,
       hoverBackgroundColor: lineColor,
       hoverBorderColor: lineColor,
@@ -176,14 +180,17 @@ ChartDataSets _generateTimeSeriesChartDataset(
       data: data);
 }
 
-ChartConfiguration generateTimeSeriesChartConfig(
-    model.Chart chart, bool dataNormalisationEnabled) {
+ChartConfiguration generateTimeSeriesChartConfig(model.Chart chart,
+    bool dataNormalisationEnabled, bool stackTimeseriesEnabled) {
   var colors = (chart.colors ?? [])..addAll(lineChartDefaultColors);
   var datasets = chart.fields.asMap().entries.map((entry) {
     var index = entry.key;
     var field = entry.value;
-    return _generateTimeSeriesChartDataset(field.label ?? field.field,
-        field.time_bucket.values.toList(), colors[index]);
+    return _generateTimeSeriesChartDataset(
+        field.label ?? field.field,
+        field.time_bucket.values.toList(),
+        colors[index],
+        stackTimeseriesEnabled ? (index == 0 ? 'origin' : '-1') : false);
   }).toList();
 
   return ChartConfiguration(
@@ -201,5 +208,6 @@ ChartConfiguration generateTimeSeriesChartConfig(
             }
           }).toList(),
           datasets: datasets),
-      options: _generateTimeSeriesChartOptions(dataNormalisationEnabled));
+      options: _generateTimeSeriesChartOptions(
+          dataNormalisationEnabled, stackTimeseriesEnabled));
 }

--- a/lib/controller.dart
+++ b/lib/controller.dart
@@ -31,6 +31,7 @@ var _currentNavLink = _navLinks['analyse'].pathname;
 int _selectedAnalysisTabIndex;
 bool _dataComparisonEnabled = true;
 bool _dataNormalisationEnabled = false;
+bool _stackTimeSeriesEnabled = true;
 Set<String> _activeFilters = {};
 Map<String, String> _filterValues = {};
 Map<String, String> _comparisonFilterValues = {};
@@ -60,6 +61,7 @@ enum UIAction {
   changeAnalysisTab,
   toggleDataComparison,
   toggleDataNormalisation,
+  toggleStackTimeseries,
   toggleActiveFilter,
   setFilterValue,
   setComparisonFilterValue,
@@ -424,7 +426,8 @@ void handleNavToAnalysis() {
   var tabLabels =
       _config.tabs.asMap().map((i, t) => MapEntry(i, t.label)).values.toList();
   view.renderAnalysisTabs(tabLabels);
-  view.renderChartOptions(_dataComparisonEnabled, _dataNormalisationEnabled);
+  view.renderChartOptions(_dataComparisonEnabled, _dataNormalisationEnabled,
+      _stackTimeSeriesEnabled);
 
   _computeFilterDropdownsAndRender();
   _computeChartBucketsAndRender();
@@ -474,7 +477,7 @@ void _computeChartBucketsAndRender() {
             chart.title,
             chart.narrative,
             chart_helper.generateTimeSeriesChartConfig(
-                chart, _dataNormalisationEnabled));
+                chart, _dataNormalisationEnabled, _stackTimeSeriesEnabled));
         break;
       case model.ChartType.map:
         var mapData =
@@ -596,6 +599,14 @@ void command(UIAction action, Data data) async {
       _dataNormalisationEnabled = d.enabled;
       logger
           .debug('Data normalisation changed to ${_dataNormalisationEnabled}');
+      view.removeAllChartWrappers();
+      _computeChartBucketsAndRender();
+      break;
+    case UIAction.toggleStackTimeseries:
+      var d = data as ToggleOptionEnabledData;
+      _stackTimeSeriesEnabled = d.enabled;
+      logger.debug(
+          'Stack time series chart changed to ${_stackTimeSeriesEnabled}');
       view.removeAllChartWrappers();
       _computeChartBucketsAndRender();
       break;

--- a/lib/controller.dart
+++ b/lib/controller.dart
@@ -8,7 +8,7 @@ import 'package:dashboard/firebase.dart' as fb;
 import 'package:dashboard/chart_helpers.dart' as chart_helper;
 import 'package:dashboard/extensions.dart';
 import 'package:dashboard/logger.dart';
-import 'package:intl/intl.dart';
+import 'package:intl/intl.dart' as intl;
 
 Logger logger = Logger('controller.dart');
 
@@ -17,7 +17,7 @@ Map<String, model.Link> _navLinks = {
   'settings': model.Link('settings', 'Settings', handleNavToSettings)
 };
 
-var STANDARD_DATE_TIME_FORMAT = DateFormat('yyyy-MM-dd HH:mm:ss');
+var STANDARD_DATE_TIME_FORMAT = intl.DateFormat('yyyy-MM-dd HH:mm:ss');
 
 const DEFAULT_FILTER_SELECT_VALUE = '__all';
 

--- a/lib/controller.dart
+++ b/lib/controller.dart
@@ -374,7 +374,6 @@ Map<String, num> _generateEmptyDateTimeBuckets(
     case model.TimeAggregate.hour:
       durationToAdd = Duration(hours: 1);
       break;
-    default:
   }
   while (currentTime.isBefore(endTime)) {
     timeBucket[STANDARD_DATE_TIME_FORMAT.format(currentTime)] = 0;

--- a/lib/controller.dart
+++ b/lib/controller.dart
@@ -48,9 +48,6 @@ Map<String, String> get _activeComparisonFilterValues => {
 Map<String, Map<String, dynamic>> _allInteractions;
 Map<String, Set> _uniqueFieldCategoryValues;
 Map<String, List<DateTime>> _allInteractionsDateRange;
-// todo: make this Map<String, Map<DateTime, num>> when Infrastructure permits
-Map<String, Map<String, num>> _allInteractionsDateBuckets =
-    {}; // "recorded_at" : { "01/01/2020": 0, "02/01/2020": 0 }
 Map<String, dynamic> _configRaw;
 model.Config _config;
 
@@ -289,13 +286,6 @@ void _computeChartBuckets(List<model.Chart> charts) {
             chart.timestamp.aggregate);
       }
     }
-    if (chart.type == model.ChartType.time_series) {
-      _allInteractionsDateBuckets[chart.timestamp.key] =
-          _generateEmptyDateTimeBuckets(
-              _allInteractionsDateRange[chart.timestamp.key][0],
-              _allInteractionsDateRange[chart.timestamp.key][1],
-              chart.timestamp.aggregate);
-    }
   }
 
   for (var interaction in _allInteractions.values) {
@@ -307,15 +297,6 @@ void _computeChartBuckets(List<model.Chart> charts) {
 
     if (addToPrimaryBucket) {
       ++_filterValuesCount;
-      for (var key in _allInteractionsDateBuckets.keys) {
-        for (var chart in charts) {
-          if (chart.type == model.ChartType.time_series) {
-            var dateTimeKey = _generateDateTimeKey(
-                interaction[key], chart.timestamp.aggregate);
-            _allInteractionsDateBuckets[key][dateTimeKey] += 1;
-          }
-        }
-      }
     }
 
     if (addToComparisonBucket) {

--- a/lib/controller.dart
+++ b/lib/controller.dart
@@ -8,6 +8,7 @@ import 'package:dashboard/firebase.dart' as fb;
 import 'package:dashboard/chart_helpers.dart' as chart_helper;
 import 'package:dashboard/extensions.dart';
 import 'package:dashboard/logger.dart';
+import 'package:intl/intl.dart';
 
 Logger logger = Logger('controller.dart');
 
@@ -15,6 +16,8 @@ Map<String, model.Link> _navLinks = {
   'analyse': model.Link('analyse', 'Analyse', handleNavToAnalysis),
   'settings': model.Link('settings', 'Settings', handleNavToSettings)
 };
+
+var STANDARD_DATE_TIME_FORMAT = DateFormat('yyyy-MM-dd HH:mm:ss');
 
 const DEFAULT_FILTER_SELECT_VALUE = '__all';
 
@@ -44,6 +47,10 @@ Map<String, String> get _activeComparisonFilterValues => {
 // Data states
 Map<String, Map<String, dynamic>> _allInteractions;
 Map<String, Set> _uniqueFieldCategoryValues;
+Map<String, List<DateTime>> _allInteractionsDateRange;
+// todo: make this Map<String, Map<DateTime, num>> when Infrastructure permits
+Map<String, Map<String, num>> _allInteractionsDateBuckets =
+    {}; // "recorded_at" : { "01/01/2020": 0, "02/01/2020": 0 }
 Map<String, dynamic> _configRaw;
 model.Config _config;
 
@@ -121,6 +128,7 @@ void onLoginCompleted() async {
   await loadGeoMapsData();
   _uniqueFieldCategoryValues =
       computeUniqFieldCategoryValues(_config.filters, _allInteractions);
+  _allInteractionsDateRange = computeDateRanges(_allInteractions);
   _selectedAnalysisTabIndex = 0;
 
   view.setNavlinkSelected(_currentNavLink);
@@ -199,6 +207,27 @@ Map<String, Set> computeUniqFieldCategoryValues(
   return uniqueFieldCategories;
 }
 
+Map<String, List<DateTime>> computeDateRanges(
+    Map<String, Map<String, dynamic>> interactions) {
+  var dateRanges = Map<String, List<DateTime>>();
+  interactions.forEach((_, interaction) {
+    interaction.keys.forEach((key) {
+      var value = interaction[key];
+      if (value is DateTime) {
+        dateRanges[key] = dateRanges[key] ?? [DateTime(2100), DateTime(1970)];
+        if (value.isBefore(dateRanges[key][0])) {
+          dateRanges[key][0] = value;
+        }
+        if (value.isAfter(dateRanges[key][1])) {
+          dateRanges[key][1] = value;
+        }
+      }
+    });
+  });
+  logger.debug('Computed date ranges for all interactions');
+  return dateRanges;
+}
+
 bool _interactionMatchesFilters(
     Map<String, dynamic> interaction, Map<String, String> filters) {
   for (var entry in filters.entries) {
@@ -247,10 +276,25 @@ void _computeChartBuckets(List<model.Chart> charts) {
   _filterValuesCount = 0;
   _comparisonFilterValuesCount = 0;
 
-  // reset bucket to [filter(0), comparisonFilter(0)] for each chart
+  // reset bucket to [filter(0), comparisonFilter(0)] for each chart col
+  // reset time_bucket to {"mm/dd/yyyy": 0} for time series chart col
+  // reset allInteractionDateBuckets (for normalising) to {"recorded_at": {"mm/dd/yyyy": 0}}
   for (var chart in charts) {
     for (var chartCol in chart.fields) {
       chartCol.bucket = [0, 0];
+      if (chart.type == model.ChartType.time_series) {
+        chartCol.time_bucket = _generateEmptyDateTimeBuckets(
+            _allInteractionsDateRange[chart.timestamp.key][0],
+            _allInteractionsDateRange[chart.timestamp.key][1],
+            chart.timestamp.aggregate);
+      }
+    }
+    if (chart.type == model.ChartType.time_series) {
+      _allInteractionsDateBuckets[chart.timestamp.key] =
+          _generateEmptyDateTimeBuckets(
+              _allInteractionsDateRange[chart.timestamp.key][0],
+              _allInteractionsDateRange[chart.timestamp.key][1],
+              chart.timestamp.aggregate);
     }
   }
 
@@ -263,6 +307,15 @@ void _computeChartBuckets(List<model.Chart> charts) {
 
     if (addToPrimaryBucket) {
       ++_filterValuesCount;
+      for (var key in _allInteractionsDateBuckets.keys) {
+        for (var chart in charts) {
+          if (chart.type == model.ChartType.time_series) {
+            var dateTimeKey = _generateDateTimeKey(
+                interaction[key], chart.timestamp.aggregate);
+            _allInteractionsDateBuckets[key][dateTimeKey] += 1;
+          }
+        }
+      }
     }
 
     if (addToComparisonBucket) {
@@ -278,6 +331,12 @@ void _computeChartBuckets(List<model.Chart> charts) {
 
         if (addToPrimaryBucket) {
           ++chartCol.bucket[0];
+          if (chart.type == model.ChartType.time_series) {
+            var dateTimeKey = _generateDateTimeKey(
+                interaction[chart.timestamp.key] as DateTime,
+                chart.timestamp.aggregate);
+            chartCol.time_bucket[dateTimeKey] += 1;
+          }
         }
         if (addToComparisonBucket) {
           ++chartCol.bucket[1];
@@ -297,11 +356,51 @@ void _computeChartBuckets(List<model.Chart> charts) {
           filterValuesPercent.roundToDecimal(2),
           comparisonFilterValuesPercent.roundToDecimal(2)
         ];
+
+        // todo: handle normalisation of time series charts
       }
     }
   }
 
   logger.debug('Computed chart buckets ${charts}');
+}
+
+String _generateDateTimeKey(DateTime dateTime, model.TimeAggregate aggregate) {
+  switch (aggregate) {
+    case model.TimeAggregate.day:
+      dateTime = DateTime(dateTime.year, dateTime.month, dateTime.day, 0, 0, 0);
+      break;
+    case model.TimeAggregate.hour:
+      dateTime = DateTime(
+          dateTime.year, dateTime.month, dateTime.day, dateTime.hour, 0, 0);
+      break;
+    default:
+      logger.error('Time series chart aggregate ${aggregate} not handled');
+  }
+  return STANDARD_DATE_TIME_FORMAT.format(dateTime);
+}
+
+Map<String, num> _generateEmptyDateTimeBuckets(
+    DateTime start, DateTime end, model.TimeAggregate aggregate) {
+  var timeBucket = Map<String, num>();
+  var currentTime = DateTime(start.year, start.month, start.day, 0, 0, 0);
+  var endTime = DateTime(end.year, end.month, end.day, 23, 59, 59);
+  var durationToAdd;
+  switch (aggregate) {
+    case model.TimeAggregate.day:
+      durationToAdd = Duration(days: 1);
+      break;
+    case model.TimeAggregate.hour:
+      durationToAdd = Duration(hours: 1);
+      break;
+    default:
+  }
+  while (currentTime.isBefore(endTime)) {
+    timeBucket[STANDARD_DATE_TIME_FORMAT.format(currentTime)] = 0;
+    currentTime = currentTime.add(durationToAdd);
+  }
+
+  return timeBucket;
 }
 
 // Render methods
@@ -350,7 +449,7 @@ void _computeChartBucketsAndRender() {
   for (var chart in charts) {
     switch (chart.type) {
       case model.ChartType.bar:
-        view.renderBarChart(
+        view.renderChart(
             chart.title,
             chart.narrative,
             chart_helper.generateBarChartConfig(
@@ -359,6 +458,13 @@ void _computeChartBucketsAndRender() {
                 _dataNormalisationEnabled,
                 _activeFilterValues,
                 _activeComparisonFilterValues));
+        break;
+      case model.ChartType.time_series:
+        view.renderChart(
+            chart.title,
+            chart.narrative,
+            chart_helper.generateTimeSeriesChartConfig(
+                chart, _dataNormalisationEnabled));
         break;
       case model.ChartType.map:
         var mapData =
@@ -594,6 +700,7 @@ void command(UIAction action, Data data) async {
 }
 
 void validateConfig(model.Config config) {
+  // todo: validate time_series chart
   // Data paths
   if (config.data_paths == null) {
     throw StateError('data_paths cannot be empty');

--- a/lib/model.yaml
+++ b/lib/model.yaml
@@ -10,16 +10,23 @@ Tab:
 
 Chart:
   type: ChartType
+  timestamp: "Timestamp" #optional
   title: "string" #optional
   narrative: "string" #optional
   fields: "array Field"
   colors: "array string" #optional
   geography: "Geography" #optional
 
+Timestamp:
+  aggregate: "TimeAggregate"
+  key: "string"
+
 Field:
   label: "string" #optional
   tooltip: "string" #optional
-  bucket: "array num" #optional
+  bucket: "array num" #computed
+  # todo: make this Map<DateTime, num> when Infrastructure permits
+  time_bucket: "map num" #computed
   field: FieldOperation
 
 FieldOperation:
@@ -60,3 +67,12 @@ ChartType:
     - bar
     - line
     - map
+    - time_series
+
+TimeAggregate:
+  dartType: "enum"
+  defaultValue: "none"
+  dartValues:
+    - day
+    - hour
+    - none

--- a/lib/view.dart
+++ b/lib/view.dart
@@ -213,7 +213,8 @@ void renderAnalysisTabs(List<String> labels) {
   content.append(wrapper);
 }
 
-void renderChartOptions(bool comparisonEnabled, bool normalisationEnabled) {
+void renderChartOptions(bool comparisonEnabled, bool normalisationEnabled,
+    bool stackTimeseriesEnabled) {
   var wrapper = generateGridRowElement(classes: [FILTER_ROW_CLASSNAME]);
   var labelCol =
       generateGridLabelColumnElement(classes: [FILTER_ROW_LABEL_CLASSNAME])
@@ -232,6 +233,14 @@ void renderChartOptions(bool comparisonEnabled, bool normalisationEnabled) {
     command(UIAction.toggleDataNormalisation, ToggleOptionEnabledData(checked));
   });
   optionsCol.append(normalisationCheckbox);
+
+  var stackTimeseriesCheckbox = _getCheckboxWithLabel(
+      'stack-timeseries',
+      'Stack time series',
+      stackTimeseriesEnabled,
+      (bool checked) => command(
+          UIAction.toggleStackTimeseries, ToggleOptionEnabledData(checked)));
+  optionsCol.append(stackTimeseriesCheckbox);
 
   wrapper.append(labelCol);
   wrapper.append(optionsCol);

--- a/lib/view.dart
+++ b/lib/view.dart
@@ -377,9 +377,9 @@ void renderFilterDropdowns(
   content.append(wrapper);
 }
 
-void renderBarChart(
+void renderChart(
     String title, String narrative, chartjs.ChartConfiguration chartConfig) {
-  var chart = _generateBarChart(title, narrative, chartConfig);
+  var chart = _generateChart(title, narrative, chartConfig);
   content.append(chart);
 }
 
@@ -464,7 +464,7 @@ void handleMapLoad(
   }
 }
 
-html.DivElement _generateBarChart(
+html.DivElement _generateChart(
     String title, String narrative, chartjs.ChartConfiguration chartConfig) {
   var wrapper = html.DivElement()..classes = [CHART_WRAPPER_CLASSNAME];
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   mapbox_gl_dart: ^0.1.4
   uuid: 2.0.4
   codemirror: ^0.5.16+5.53.0
+  intl: ^0.16.1
 
 dev_dependencies:
   build_runner: ^1.6.0


### PR DESCRIPTION
Model:
+ Added additional chart type `time_series` and its corresponding property for the date time and bucket interval
+ `time_bucket` should ideally be `Map<DateTime, num>`, will update once Infrastructure allows

View:
+ Renamed the render bar chart method to renderChart as it is a matter of passing the right chart type config

Chart helper:
+ Added methods to generate time series options and config
+ Up coming: flags to stack time series, normalised values

Controller:
+ Additional property to compute the date ranges for each of the interaction keys with DateTime value, so I can generate the date time buckets
+ `_computeChartBuckets` now take into account the date ranges to be bucketed based on the bucket interval for time series chart
+ `_generateDateTimeKey` should ideally return date time than formatted string, will update it once the Infrastructure allows map with non string keys
+ Upcoming: normalisation, stacking of time series charts
