### PR TITLE
Use chartjs 2.9 instead of 2.6

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -16,7 +16,7 @@
     <script src="https://www.gstatic.com/firebasejs/7.6.1/firebase-analytics.js"></script>
     <script src="https://www.gstatic.com/firebasejs/7.6.1/firebase-auth.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/moment@2.24.0/moment.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.6.0/Chart.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@2.9.0/dist/Chart.bundle.js"></script>
     <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v1.5.0/mapbox-gl.js"></script>
     <link
       href="https://api.tiles.mapbox.com/mapbox-gl-js/v1.5.0/mapbox-gl.css"


### PR DESCRIPTION
This seems to solve the issues with the tooltips disappearing - my best guess is that some of the chart options have changed between these two versions, resulting in the behaviour we were observing.